### PR TITLE
Add formula test for usage message

### DIFF
--- a/Formula/home-server.rb
+++ b/Formula/home-server.rb
@@ -11,4 +11,8 @@ class HomeServer < Formula
     bin.install "scripts/home-server-setup"
     pkgshare.install Dir["files/*"]
   end
+
+  test do
+    assert_match "Usage: home-server-setup", shell_output("#{bin}/home-server-setup --help invalid", 1)
+  end
 end


### PR DESCRIPTION
## Summary
- add a `test do` block in `home-server.rb` ensuring `home-server-setup` prints usage

## Testing
- `brew test Formula/home-server.rb` *(fails: `brew: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6841b0fa5878832ba1dabd010af848f3