### PR TITLE
Fix HTTP links in dashboard template

### DIFF
--- a/files/index.html.tmpl
+++ b/files/index.html.tmpl
@@ -38,10 +38,10 @@
 <body>
   <h1>{{DOMAIN}} Services</h1>
   <ul class="services">
-    <li><a href="https://unifi.{{DOMAIN}}">UniFi Controller</a></li>
-    <li><a href="https://pms.{{DOMAIN}}">Plex Media Server</a></li>
-    <li><a href="https://ha.{{DOMAIN}}">Home Assistant</a></li>
-    <li><a href="https://qbittorrent.{{DOMAIN}}">qBittorrent</a></li>
+    <li><a href="http://unifi.{{DOMAIN}}">UniFi Controller</a></li>
+    <li><a href="http://pms.{{DOMAIN}}">Plex Media Server</a></li>
+    <li><a href="http://ha.{{DOMAIN}}">Home Assistant</a></li>
+    <li><a href="http://qbittorrent.{{DOMAIN}}">qBittorrent</a></li>
   </ul>
 </body>
 </html>
@@ -85,10 +85,10 @@
 <body>
   <h1>{{DOMAIN}} Services</h1>
   <ul class="services">
-    <li><a href="https://unifi.{{DOMAIN}}">UniFi Controller</a></li>
-    <li><a href="https://pms.{{DOMAIN}}">Plex Media Server</a></li>
-    <li><a href="https://ha.{{DOMAIN}}">Home Assistant</a></li>
-    <li><a href="https://qbittorrent.{{DOMAIN}}">qBittorrent</a></li>
+    <li><a href="http://unifi.{{DOMAIN}}">UniFi Controller</a></li>
+    <li><a href="http://pms.{{DOMAIN}}">Plex Media Server</a></li>
+    <li><a href="http://ha.{{DOMAIN}}">Home Assistant</a></li>
+    <li><a href="http://qbittorrent.{{DOMAIN}}">qBittorrent</a></li>
   </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use the http protocol for local service links in `index.html.tmpl`

## Testing
- `scripts/home-server-setup --help` *(fails: `brew: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6841b0f4d080832b9a2c70ab7f59451f